### PR TITLE
removed bad styles on team page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "gatsby-starter-default",
-  "version": "2.1.0",
+  "name": "ew-main-website",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/pages/team.js
+++ b/src/pages/team.js
@@ -69,7 +69,7 @@ const TeamPage = () => {
         </section>
 
         <section className={cx(styles.gridContainer12, 'content')}>
-          <h2 className={cx(styles, 'content-max-width')}>Meet the Team</h2>
+          <h2 className={cx('content-max-width')}>Meet the Team</h2>
           <div className={styles.team}>
             {teamData.map((person) => (
               <div key={person.node.id} className={styles.person}>
@@ -92,7 +92,7 @@ const TeamPage = () => {
         <br />
 
         <section className={cx(styles.gridContainer12, 'content')}>
-          <h2 className={cx(styles, 'content-max-width')}>We're Hiring</h2>
+          <h2 className={cx('content-max-width')}>We're Hiring</h2>
           <div>
             <p>
               We're always looking for highly-motivated, mission-driven people


### PR DESCRIPTION
Fixed it so the h2s aren't smushed into the top left.

<img width="1440" alt="Screen Shot 2021-11-30 at 10 45 30 AM" src="https://user-images.githubusercontent.com/13904823/144091706-21882943-8144-4334-8481-e637db458abc.png">
