### PR TITLE
Remove image from Careers page

### DIFF
--- a/src/pages/careers.js
+++ b/src/pages/careers.js
@@ -1,10 +1,7 @@
 import React from 'react';
-import { StaticImage } from 'gatsby-plugin-image';
-import cx from 'classnames';
 import Layout from 'components/Layout';
 import SEO from 'components/seo';
 import Button from 'components/Button';
-import styles from './careers.module.scss';
 
 const TeamPage = () => {
   return (
@@ -12,12 +9,6 @@ const TeamPage = () => {
       <SEO title="Careers" />
       <section className="content">
         <h1>Careers</h1>
-        <div className={cx(styles.mainImage)}>
-          <StaticImage
-            src="../_assets/images/group1.png"
-            alt="Members of the Emergent Works team"
-          />
-        </div>
         <p>
           Are you tired of working on problems with solutions that don't drive
           positive social change? Do you want to work with a group of people as


### PR DESCRIPTION
## 🚀 What's New

Removes the team image from the Careers page, per Army/Keyana's request

## 📸 Screenshots (if applicable)
![Image 2023-03-08 at 12 40 48 PM](https://user-images.githubusercontent.com/22643036/223788874-edff41b0-17f5-4e16-9da9-9ae86a11bc5f.jpg)

## 📝 Additional information
